### PR TITLE
Sync source code from InMage-ASRDFD for release 9.67 Update1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -33,7 +33,7 @@ ifeq (, $(VERSION_MINOR))
 endif
 
 ifeq (, $(VERSION_BUILDNUM))
-	VERSION_BUILDNUM:=6
+	VERSION_BUILDNUM:=7
 endif
 
 ifeq (, $(VERSION_PRIVATE))
@@ -87,8 +87,8 @@ ifeq ($(findstring suse, $(VENDOR)), suse)
 		endif
 	else
 		DISTRO_VER:=$(shell export PATH=/bin:/sbin:/usr/bin:/usr/sbin:$PATH;\
-				grep VERSION= /etc/os-release | cut -d"\"" -f 2 | \
-				cut -d"-" -f 1)
+				grep '^VERSION=' /etc/os-release | cut -d"\"" -f 2 | \
+				cut -d"-" -f 1 | cut -d"." -f 1)
 		PATCH_LEVEL:=$(shell export PATH=/bin:/sbin:/usr/bin:/usr/sbin:$PATH;\
 				grep -o -- -SP[0-9] /etc/os-release | cut -d"P" -f 2)
 		VENDOR:=suse
@@ -100,6 +100,12 @@ ifeq ($(findstring suse, $(VENDOR)), suse)
 	ifeq ($(DISTRO_VER), 12)
 		INM_CFLAGS += -mindirect-branch=thunk-inline -mindirect-branch-register
 	endif
+endif
+
+ifeq ($(findstring debian, $(VENDOR)), debian)
+	DISTRO_VER:=$(shell export PATH=/bin:/sbin:/usr/bin:/usr/sbin:$PATH;\
+			cat /etc/debian_version | cut -d"." -f 1 | cut -d"/" -f 1)
+	INM_CFLAGS += -DDISTRO_VER=${DISTRO_VER}
 endif
 
 ifeq ($(findstring redhat, $(VENDOR)), redhat)
@@ -195,6 +201,17 @@ ifeq ($(findstring redhat, $(VENDOR)), redhat)
 
 	ifeq ($(findstring 5.14.0-611, $(KDIR)), 5.14.0-611)
 		INM_CFLAGS += -DRHEL9_7
+	endif
+
+	# Define RHEL9_8_OR_LATER for kernel versions 5.14.0-650 and above
+	# RHEL 9.8 kernel is 5.14.0-687. This covers 9.8+ without listing future versions.
+	ifeq ($(findstring 5.14.0, $(KDIR)), 5.14.0)
+		RHEL9_BUILD_NUM := $(shell echo $(KDIR) | grep -oE '5\.14\.0-[0-9]+' | cut -d'-' -f2)
+		ifneq ($(RHEL9_BUILD_NUM),)
+			ifeq ($(shell test $(RHEL9_BUILD_NUM) -ge 650 2>/dev/null && echo true), true)
+				INM_CFLAGS += -DRHEL9_8_OR_LATER
+			endif
+		endif
 	endif
 
 	ifeq ($(findstring uek, $(KDIR)), uek)

--- a/src/distro.h
+++ b/src/distro.h
@@ -76,6 +76,17 @@
 #endif
 #endif
 
+#if (defined suse && DISTRO_VER == 16)
+#define SLES16
+#endif
+
+/* Debian */
+#if (defined debian && DISTRO_VER == 12)
+#define DEBIAN12
+#elif (defined debian && DISTRO_VER == 13)
+#define DEBIAN13
+#endif
+
 /* RHEL */
 #if (defined redhat && DISTRO_VER == 10)
 #define RHEL10

--- a/src/file-io.c
+++ b/src/file-io.c
@@ -38,8 +38,11 @@
 #include <linux/dcache.h>
 #include <linux/fs_struct.h>
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7)
 #include <linux/filelock.h>
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
+#include <linux/namei.h>
 #endif
 
 extern driver_context_t *driver_ctx;
@@ -505,6 +508,9 @@ inm_mkdir(char *dir_name, inm_s32_t mode)
 			break;
 		}
 		dir = inm_lookup_create(&nameidata, 1);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
+		dir = start_creating_path(AT_FDCWD, tmp, &nameidata.path,
+							LOOKUP_DIRECTORY);
 #else
 		dir = kern_path_create(AT_FDCWD, tmp, &nameidata.path,
 							LOOKUP_DIRECTORY);
@@ -519,7 +525,29 @@ inm_mkdir(char *dir_name, inm_s32_t mode)
 				mode &= ~current->fs->umask;
 			dbg("Coming in inm_mkdir befor vfs_mkdir\n");
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_6) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+			/* vfs_mkdir returns struct dentry * and takes delegated_inode.
+			 * NULL delegation is safe: ASR only creates local appliance paths,
+			 * so delegation retry (as done in __inm_unlink) is not needed.
+			 * Assign dir unconditionally so cleanup uses the correct dentry. */
+			dir = vfs_mkdir(mnt_idmap(nameidata.path.mnt),
+						nameidata.path.dentry->d_inode,
+						dir, mode, NULL);
+			if (IS_ERR(dir))
+				err = PTR_ERR(dir);
+			else
+				err = 0;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,16,0)
+			/* vfs_mkdir returns struct dentry * since 6.16.
+			 * Assign dir unconditionally so cleanup uses the correct dentry. */
+			dir = vfs_mkdir(mnt_idmap(nameidata.path.mnt),
+						nameidata.path.dentry->d_inode,
+						dir, mode);
+			if (IS_ERR(dir))
+				err = PTR_ERR(dir);
+			else
+				err = 0;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7)
 			err = vfs_mkdir(mnt_idmap(nameidata.path.mnt),
 						nameidata.path.dentry->d_inode,
 						dir, mode);
@@ -550,6 +578,8 @@ inm_mkdir(char *dir_name, inm_s32_t mode)
 			dbg("Coming in inm_mkdir after vfs_mkdir\n");
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 8, 13)
 			dput(dir);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
+			end_creating_path(&nameidata.path, dir);
 #else
 			done_path_create(&nameidata.path, dir);
 #endif
@@ -604,7 +634,11 @@ __inm_unlink(const char * pathname, char *parent_path)
 	struct file     *parent_hdl = NULL;
 	struct path		path;
 	struct dentry	*dentry = NULL;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+	struct delegated_inode deleg = { };
+#else
 	struct inode    *deleg = NULL;
+#endif
 	int             retry = 0;
    
 	dbg("Unlink called on %s, parent = %s", pathname, parent_path);
@@ -617,7 +651,11 @@ __inm_unlink(const char * pathname, char *parent_path)
 		parent_inode = INM_HDL_TO_INODE(parent_hdl);
 
 		do {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+			deleg = (struct delegated_inode){ };
+#else
 			deleg = NULL;
+#endif
 			retry = 0;
 
 			error = kern_path(name, 0, &path);
@@ -633,7 +671,7 @@ __inm_unlink(const char * pathname, char *parent_path)
 #endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_6) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7)
 				error = vfs_unlink(mnt_idmap(path.mnt),
 							parent_inode,
 							dentry, &deleg);
@@ -646,7 +684,11 @@ __inm_unlink(const char * pathname, char *parent_path)
 				error = vfs_unlink(parent_inode, dentry,
 							&deleg);
 #endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+				if (error && !is_delegated(&deleg))
+#else
 				if (error && !deleg)
+#endif
 					err("vfs_unlink failed with error %d",
 								error);
 		
@@ -661,6 +703,16 @@ __inm_unlink(const char * pathname, char *parent_path)
 				dbg("Path lookup failed: %d", error);
 			}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+			if (is_delegated(&deleg)) {
+				error = break_deleg_wait(&deleg);
+				if (error)
+					err("Cannot break delegation, error %d",
+								error);
+				else
+					retry = 1;
+			}
+#else
 			if (deleg) {
 				error = break_deleg_wait(&deleg);
 				if (error)
@@ -669,6 +721,7 @@ __inm_unlink(const char * pathname, char *parent_path)
 				else
 					retry = 1;
 			}
+#endif
 		} while(retry);
 		/* cant use deleg as deleg=NULL in break_deleg_wait()*/
 

--- a/src/filter_host.c
+++ b/src/filter_host.c
@@ -1,4 +1,4 @@
-﻿/* SPDX-License-Identifier: GPL-2.0-only */
+/* SPDX-License-Identifier: GPL-2.0-only */
 
 /* Copyright (C) 2022 Microsoft Corporation
  *
@@ -219,7 +219,7 @@ inm_exchange_strategy(host_dev_ctx_t *hdcp)
 			(void)xchg(&q_info->q->make_request_fn, 
 				  		q_info->orig_make_req_fn);
 #endif
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 			(void)xchg(&q_info->q->disk->queue_kobj.ktype, q_info->orig_kobj_type);
 #else
 			(void)xchg(&q_info->q->kobj.ktype, q_info->orig_kobj_type);
@@ -370,7 +370,7 @@ alloc_and_init_qinfo(inm_block_device_t *bdev, target_context_t *ctx)
 
 	INM_SPIN_LOCK_IRQSAVE(&driver_ctx->dc_host_info.rq_list_lock, 
 			 					lock_flag);
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	q_info = get_qinfo_from_kobj(&bdev->bd_disk->queue_kobj);
 #else
 	q_info = get_qinfo_from_kobj(&bdev->bd_disk->queue->kobj);
@@ -389,7 +389,7 @@ alloc_and_init_qinfo(inm_block_device_t *bdev, target_context_t *ctx)
 #endif
 	q_info->q = q;
 	
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	if (q->disk->queue_kobj.ktype) {
 		memcpy_s(&(q_info->mod_kobj_type), sizeof(struct kobj_type),
 			q->disk->queue_kobj.ktype, sizeof(struct kobj_type));
@@ -409,7 +409,7 @@ alloc_and_init_qinfo(inm_block_device_t *bdev, target_context_t *ctx)
 	INM_ATOMIC_SET(&q_info->vol_users, 0);
 
 	q_info->mod_kobj_type.release = flt_queue_obj_rel;
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	q_info->orig_kobj_type =  q->disk->queue_kobj.ktype;
 #else
 	q_info->orig_kobj_type =  q->kobj.ktype;
@@ -430,7 +430,7 @@ alloc_and_init_qinfo(inm_block_device_t *bdev, target_context_t *ctx)
 	/* now exchange pointers for make_request function and kobject type */
 	(void)xchg(&q->make_request_fn, &flt_make_request_fn);
 #endif
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	(void)xchg(&q->disk->queue_kobj.ktype, &q_info->mod_kobj_type);
 #else
 	(void)xchg(&q->kobj.ktype, &q_info->mod_kobj_type);
@@ -1183,13 +1183,41 @@ static void
 flt_orig_endio(struct bio *bio, inm_s32_t error)
 {
 	dbg("ENDIO: %p", bio);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+	/*
+	 * Since kernel 6.19, bio_chain_endio() is a sentinel function that
+	 * unconditionally calls BUG(). It must never be called directly.
+	 * The kernel's bio_endio() detects the sentinel by checking
+	 * bi_end_io == bio_chain_endio and handles chained bios via
+	 * __bio_chain_endio() internally. We must route all bio completions
+	 * through bio_endio() instead of calling bi_end_io() directly,
+	 * since we cannot distinguish chained vs non-chained bios here
+	 * (bio_chain_endio is not exported).
+	 */
+	bio_endio(bio);
+#else
 	if (bio->bi_end_io)
 		return bio->bi_end_io(bio);
+#endif
 }
 
 void 
 flt_end_io_fn(struct bio *bio)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+	/*
+	 * Since kernel 6.19, the block layer no longer advances
+	 * bio->bi_iter on completion, so bi_size stays at its original
+	 * value for both success and error bios. We must always reset
+	 * it to 0 to match pre-6.19 behavior where bio_endio() consumed
+	 * bi_iter. This is critical for flt_copy_bio() which uses
+	 * INM_BUF_COUNT(bio) == 0 as the condition to free bio_info and
+	 * release the target context reference via put_tgt_ctxt().
+	 * Without this, error bios leak the tgt_ctx reference, preventing
+	 * volume cleanup and causing D-state hangs between CVT tests.
+	 */
+	INM_BUF_COUNT(bio) = 0;
+#else
 	dm_bio_info_t *bio_info = bio->bi_private;
 	target_context_t *ctx = (target_context_t *)bio_info->tc;
 
@@ -1203,6 +1231,7 @@ flt_end_io_fn(struct bio *bio)
 		}
 		INM_BUG_ON(INM_BUF_COUNT(bio) != 0);
 	}
+#endif
 
 	flt_end_io(bio, inm_bio_error(bio));
 }
@@ -1457,6 +1486,7 @@ int
 is_our_io(struct bio *biop) 
 {
 	struct bio_vec *bvecp = NULL;
+	struct address_space *mapping = NULL;
 	const inm_address_space_operations_t *a_opsp = NULL;
 	inma_ops_t *t_inma_opsp = NULL;
 	unsigned long lock_flag;
@@ -1517,22 +1547,27 @@ is_our_io(struct bio *biop)
 		return FALSE;
 	}
 
-	if (!bvecp->bv_page->mapping)
+	/*
+	 * Cache mapping once with READ_ONCE to prevent TOCTOU race.
+	 * The page can be freed and recycled between reads on PREEMPT
+	 * kernels, causing mapping to become a poison value.
+	 */
+	mapping = READ_ONCE(bvecp->bv_page->mapping);
+
+	if (!mapping)
 	{
 		if (logErr) {
 			dbg("Invalid bio bvecp->bv_page->mapping: %p, bvecp = %p, bv_page = %p, mapping = %p", 
-					biop, bvecp, bvecp->bv_page, 
-					(bvecp->bv_page ? bvecp->bv_page->mapping : NULL));
+					biop, bvecp, bvecp->bv_page, mapping);
 		}
 		return FALSE;
 	}
 
-	if (!virt_addr_valid(bvecp->bv_page->mapping))
+	if (!virt_addr_valid(mapping))
 	{
 		if (logErr) {
 			dbg("Invalid bio virt_addr_valid: %p, bvecp = %p, bv_page = %p, mapping = %p", 
-					biop, bvecp, bvecp->bv_page, 
-					(bvecp->bv_page ? bvecp->bv_page->mapping : NULL));
+					biop, bvecp, bvecp->bv_page, mapping);
 		}
 		return FALSE;
 	}
@@ -1540,19 +1575,18 @@ is_our_io(struct bio *biop)
 	{	
 		if (logErr) {	
 			dbg("Invalid bio PageAnon: %p, bvecp = %p, bv_page = %p, mapping = %p", 
-					biop, bvecp, bvecp->bv_page, 
-					(bvecp->bv_page ? bvecp->bv_page->mapping : NULL));
+					biop, bvecp, bvecp->bv_page, mapping);
 		}
 		return FALSE;
 	}
 
 #ifdef INM_RECUSIVE_ADSPC 
-	a_opsp = bvecp->bv_page->mapping;
+	a_opsp = mapping;
 #else
-	if (!bvecp->bv_page->mapping->a_ops)
+	if (!mapping->a_ops)
 		return FALSE;
 
-	a_opsp = bvecp->bv_page->mapping->a_ops;
+	a_opsp = mapping->a_ops;
 #endif
 
 	lock_inmaops(FALSE, &lock_flag);
@@ -1561,8 +1595,7 @@ is_our_io(struct bio *biop)
 	unlock_inmaops(FALSE, &lock_flag);
 	if (t_inma_opsp) {
 #ifdef INM_RECUSIVE_ADSPC
-		INM_BUG_ON(t_inma_opsp->ia_mapping != 
-				  		bvecp->bv_page->mapping);
+		INM_BUG_ON(t_inma_opsp->ia_mapping != mapping);
 #endif
 		dbg("Recursive write: Lookup = %p, Mapping = %p", 
 				  			t_inma_opsp, a_opsp);
@@ -2061,7 +2094,7 @@ blk_status_t inm_queue_rq(struct blk_mq_hw_ctx *hctx,
 
 	INM_SPIN_LOCK_IRQSAVE(&driver_ctx->dc_host_info.rq_list_lock, 
 			 					lock_flag);
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7)  || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER)  || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	q_info = get_qinfo_from_kobj(&q->disk->queue_kobj);
 #else
 	q_info = get_qinfo_from_kobj(&q->kobj);
@@ -2089,7 +2122,7 @@ out_orig_queue_rq_fn:
 }
 
 #ifdef INM_QUEUE_RQS_ENABLED
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) || defined(RHEL9_7) || (defined(RHEL10) && UPDATE != 0) || (defined(debian) && LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || (defined(RHEL10) && UPDATE != 0) || defined(SLES16) || defined(DEBIAN13) || (defined(DEBIAN12) && LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
 void inm_queue_rqs(struct rq_list *rqlist)
 #else
 void inm_queue_rqs(struct request **rqlist)
@@ -2109,7 +2142,7 @@ void inm_queue_rqs(struct request **rqlist)
 	/* Acquire lock once and look up context once for the entire batch */
 	INM_SPIN_LOCK_IRQSAVE(&driver_ctx->dc_host_info.rq_list_lock, 
 							lock_flag);
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	q_info = get_qinfo_from_kobj(&q->disk->queue_kobj);
 #else
 	q_info = get_qinfo_from_kobj(&q->kobj);
@@ -2180,7 +2213,7 @@ flt_make_request_fn(struct request_queue *q, struct bio *bio)
 		orig_make_request_fn = q_info->orig_make_req_fn;
 	}else{
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0) || defined SLES12SP4 || \
-				defined SLES12SP5 || defined SLES15
+				defined SLES12SP5 || defined SLES15 || defined SLES16
 		struct request_queue *q = bio->bi_disk->queue;
 #else
 		struct request_queue *q = bdev_get_queue(bio->bi_bdev);
@@ -2235,7 +2268,7 @@ flt_make_request_fn(struct request_queue *q, struct bio *bio)
 			INM_UP_READ(&driver_ctx->tgt_list_sem);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0) || defined SLES12SP4 || \
-				defined SLES12SP5 || defined SLES15
+				defined SLES12SP5 || defined SLES15 || defined SLES16
 			bio->bi_status = BLK_STS_IOERR;
 #else
 			bio->bi_error = -EIO;
@@ -2431,7 +2464,7 @@ void flt_disk_obj_rel(struct kobject *kobj)
 	if (!disk->queue)
 		goto out;
 
-#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#if defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
 	qkobj = &disk->queue_kobj;
 #else
 	qkobj = &disk->queue->kobj;
@@ -2487,7 +2520,11 @@ static inm_s32_t completion_check_endio(struct bio *bio, inm_u32_t done,
 	req = bio->bi_private;
 	ctx = req->ctx;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+	if(in_hardirq()) {
+#else
 	if(in_irq()) {
+#endif
 		dbg("Completion called in Interrupt context for %s", ctx->tc_guid);
 		ctx->tc_lock_fn = volume_lock_irqsave;
 		ctx->tc_unlock_fn = volume_unlock_irqrestore;

--- a/src/filter_host.h
+++ b/src/filter_host.h
@@ -58,7 +58,8 @@ typedef blk_status_t (queue_rq_fn)(struct blk_mq_hw_ctx *,
 #endif
 blk_status_t inm_queue_rq(struct blk_mq_hw_ctx *hctx, const struct blk_mq_queue_data *bd);
 #ifdef INM_QUEUE_RQS_ENABLED
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) || defined(RHEL9_7) || (defined(RHEL10) && UPDATE != 0) || (defined(debian) && LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || (defined(RHEL10) && UPDATE != 0) || defined(SLES16) || defined(DEBIAN13) || (defined(DEBIAN12) && LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0))
+struct rq_list;
 #ifndef queue_rqs_fn
 typedef void (queue_rqs_fn)(struct rq_list *);
 #endif
@@ -130,7 +131,7 @@ do{                                                                     \
 }while(0)
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,0)
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0) || defined(RHEL9_6) || defined(RHEL9_7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER)
 #define	INM_QUEUE_FEATURES(q)	((q)->limits.features)
 #define	SET_STABLE_PAGES(q)	(INM_QUEUE_FEATURES(q) |= BLK_FEAT_STABLE_WRITES)
 #define	CLEAR_STABLE_PAGES(q)	(INM_QUEUE_FEATURES(q) &= ~BLK_FEAT_STABLE_WRITES)

--- a/src/flt_bio.h
+++ b/src/flt_bio.h
@@ -83,7 +83,7 @@ typedef struct block_device inm_bio_dev_t;
 #endif  
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0) || \
-	defined SLES12SP4 || defined SLES12SP5 || defined SLES15
+	defined SLES12SP4 || defined SLES12SP5 || defined SLES15 || defined SLES16
 #define inm_bio_error(bio) ((bio)->bi_status)
 #else
 #define inm_bio_error(bio) ((bio)->bi_error)
@@ -180,7 +180,7 @@ typedef unsigned short inm_bvec_iter_t;
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)) || defined SLES12SP3
 
 #define INM_REQ_WRITE           REQ_OP_WRITE
-#if (defined(RHEL9) && !defined(RHEL9_0) && !defined(OL9UEK7)) || defined(SLES15SP5) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
+#if (defined(RHEL9) && !defined(RHEL9_0) && !defined(OL9UEK7)) || defined(SLES15SP5) || defined(SLES16) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
 /* Defining it as 100000000 to not match with any req_op */
 #define INM_REQ_WRITE_SAME      100000000
 #else
@@ -286,14 +286,14 @@ INM_IS_SUPPORTED_REQUEST_OP(struct bio *bio)
 
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)    */
 
-/* 
- * For unsupported kernels, break build so we are forced to verify 
- * we are logging the right data.
+/*
+ * Combine bio request flags and bi_flags for change tracking.
+ * Different kernel versions store these fields differently.
  */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,20,0))
-#define INM_BIO_RW_FLAGS(bio)   (*bio = 0)
+#define INM_BIO_RW_FLAGS(bio)   (inm_bio_rw(bio) | bio->bi_flags)
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)) || defined SLES12SP3
-#define INM_BIO_RW_FLAGS(bio)   (inm_bio_rw(bio) | bio->bi_flags) 
+#define INM_BIO_RW_FLAGS(bio)   (inm_bio_rw(bio) | bio->bi_flags)
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0))
 #define INM_BIO_RW_FLAGS(bio)   (inm_bio_rw(bio) << 32 | bio->bi_flags)
 #else

--- a/src/inm_mem.h
+++ b/src/inm_mem.h
@@ -94,6 +94,16 @@ int INM_UNPIN(void *addr, size_t size)
 #define INM_KMEM_CACHE_FREE_PATH(cachep, objp, heap)				\
 						INM_KMEM_CACHE_FREE(cachep, objp)
 
+/* names_cachep removed in kernel 7.0; use kmalloc/kfree for path allocations */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+#undef INM_KMEM_CACHE_ALLOC_PATH
+#undef INM_KMEM_CACHE_FREE_PATH
+#define INM_KMEM_CACHE_ALLOC_PATH(cachep, flags, size, heap)			\
+						((char *)kmalloc(size, flags))
+#define INM_KMEM_CACHE_FREE_PATH(cachep, objp, heap)				\
+						kfree(objp)
+#endif
+
 #define INM_MEMPOOL_CREATE(min_nr, alloc_slab, free_slab, cachep)	\
 	mempool_create(min_nr, alloc_slab, free_slab, cachep)
 #define INM_MEMPOOL_FREE(objp, poolp)           inm_mempool_free(objp, poolp)

--- a/src/inm_utypes.h
+++ b/src/inm_utypes.h
@@ -41,7 +41,7 @@ typedef struct bio		inm_buf_t;
 struct drv_open{
 	const struct block_device_operations *orig_dev_ops;
 	struct block_device_operations mod_dev_ops;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7)
 	int (*orig_drv_open)(struct gendisk *disk, blk_mode_t mode);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
 	int (*orig_drv_open)(struct block_device *bdev, fmode_t mode);

--- a/src/osdep.c
+++ b/src/osdep.c
@@ -61,7 +61,7 @@
 #include "distro.h"
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0) || defined SLES12 || \
-		defined SLES15
+		defined SLES15 || defined SLES16
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,10,0) || defined SLES12 || \
 		defined SLES15 && !defined(SLES15SP6) && !defined(SLES15SP7)
 #include <linux/slab_def.h>
@@ -72,7 +72,7 @@ extern driver_context_t *driver_ctx;
 
 atomic_t inm_flt_memprint;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7) || defined(SLES16)
 static int
 inm_sd_open(struct gendisk *disk, blk_mode_t mode);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
@@ -1132,7 +1132,7 @@ replace_sd_open(void)
 	driver_ctx->dc_at_lun.dc_at_drv_info.mod_dev_ops.open = inm_sd_open;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7) || defined(SLES16)
 static int
 inm_sd_open(struct gendisk *disk, blk_mode_t mode)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
@@ -1144,7 +1144,7 @@ inm_sd_open(struct inode *inode, struct file *filp)
 #endif
 {
 	 inm_s32_t err = 0;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) && !defined(RHEL9_4) && !defined(RHEL9_5) && !defined(RHEL9_6) && !defined(RHEL9_7) && !defined(SLES15SP6) && !defined(SLES15SP7)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) && !defined(RHEL9_4) && !defined(RHEL9_5) && !defined(RHEL9_6) && !defined(RHEL9_7) && !defined(RHEL9_8_OR_LATER) && !defined(SLES15SP6) && !defined(SLES15SP7) && !defined(SLES16)
 	 struct gendisk *disk = NULL;
 #endif
 	 struct scsi_device *sdp = NULL;
@@ -1154,7 +1154,7 @@ inm_sd_open(struct inode *inode, struct file *filp)
 		 goto out;
 	 } 
 	 INM_ATOMIC_INC(&(driver_ctx->dc_at_lun.dc_at_drv_info.nr_in_flight_ops));
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || defined(SLES15SP6) || defined(SLES15SP7) || defined(SLES16)
 	 err = driver_ctx->dc_at_lun.dc_at_drv_info.orig_drv_open(disk, mode);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
 	 err = driver_ctx->dc_at_lun.dc_at_drv_info.orig_drv_open(bdev, mode);
@@ -1162,7 +1162,7 @@ inm_sd_open(struct inode *inode, struct file *filp)
 	 err = driver_ctx->dc_at_lun.dc_at_drv_info.orig_drv_open(inode, filp);
 #endif
 	 if(!err) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) && !defined(RHEL9_4) && !defined(RHEL9_5) && !defined(RHEL9_6) && !defined(RHEL9_7) && !defined(SLES15SP6) && !defined(SLES15SP7)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) && !defined(RHEL9_4) && !defined(RHEL9_5) && !defined(RHEL9_6) && !defined(RHEL9_7) && !defined(RHEL9_8_OR_LATER) && !defined(SLES15SP6) && !defined(SLES15SP7) && !defined(SLES16)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,32)
 		disk = bdev->bd_disk;
 #else
@@ -1637,7 +1637,7 @@ inm_file_open_by_devnum(dev_t dev, unsigned mode)
 struct block_device *
 inm_open_by_devnum(dev_t dev, unsigned mode)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_4) || defined(SLES15SP6) || defined(SLES15SP7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0) || defined(RHEL9_4) || defined(SLES15SP6) || defined(SLES15SP7) || defined(SLES16)
 	return blkdev_get_by_dev(dev, mode, NULL, NULL);
 #elif LINUX_VERSION_CODE > KERNEL_VERSION(2,6,35)
 	return blkdev_get_by_dev(dev, mode, NULL);
@@ -3974,7 +3974,7 @@ log_console(const char *fmt, ...)
 void
 inm_blkdev_name(inm_bio_dev_t *bdev, char *name)
 {
-#if defined(RHEL9_2) || defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+#if defined(RHEL9_2) || defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
 	snprintf(name, INM_BDEVNAME_SIZE, "%pg", bdev);
 #else
 	bdevname(bdev, name);
@@ -3990,7 +3990,7 @@ inm_blkdev_get(inm_bio_dev_t *bdev)
 #elif defined(INM_FILP_FOR_BDEV_ENABLED)
 	return (IS_ERR(bdev_file_open_by_dev(bdev->bd_dev,
 			FMODE_READ | FMODE_WRITE, NULL, NULL)) ? 1: 0);
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL9_4) || defined(SLES15SP6) || defined(SLES15SP7)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || defined(RHEL9_4) || defined(SLES15SP6) || defined(SLES15SP7) || defined(SLES16)
 	return (IS_ERR(blkdev_get_by_dev(bdev->bd_dev,
 			BLK_OPEN_READ | BLK_OPEN_WRITE, NULL, NULL)) ? 1 : 0);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)

--- a/src/osdep.h
+++ b/src/osdep.h
@@ -54,6 +54,14 @@
 
 #include "distro.h"
 
+/*
+ * READ_ONCE was introduced in kernel 3.19 as a replacement for ACCESS_ONCE.
+ * Provide a compat shim for older kernels (OL7 UEK3, early RHEL7).
+ */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0) && !defined(READ_ONCE)
+#define READ_ONCE(x) ACCESS_ONCE(x)
+#endif
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 12, 0)
 #include <linux/time.h>
 #else
@@ -90,7 +98,7 @@
 #define HAVE_BI_SIZE
 #endif
 
-#if defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
+#if defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(6, 10, 0)
 #ifndef INM_FILP_FOR_BDEV_ENABLED
 #define INM_FILP_FOR_BDEV_ENABLED
 #endif
@@ -546,7 +554,7 @@ typedef struct completion		inm_completion_t;
 		init_completion(event)
 #define INM_DESTROY_COMPLETION(compl)
 
-#if defined(RHEL9_2) || defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
+#if defined(RHEL9_2) || defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
 #define INM_COMPLETE_AND_EXIT(event, val)				\
 		kthread_complete_and_exit(event, val)
 #else
@@ -816,6 +824,19 @@ int _inm_xm_mapin(struct _target_context *, void *, char **);
  */
 #define INM_IMB_ERROR_SET(var, error_value) 
 #define INM_MIRROR_IODONE(fn, bp, done, error) fn(inm_buf_t *bp)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,19,0)
+/*
+ * Since kernel 6.19, bio_chain_endio() is a sentinel that calls BUG() if
+ * invoked directly. Must use bio_endio() which handles the sentinel check.
+ */
+#define INM_PT_IODONE(mbufinfo)                                                 	\
+{                                                                               	\
+	mbufinfo->imb_org_bp->bi_flags = mbufinfo->imb_pt_buf.bi_flags;         	\
+	INM_BUF_COUNT(mbufinfo->imb_org_bp) = INM_BUF_COUNT(&(mbufinfo->imb_pt_buf));   \
+	inm_bio_error(mbufinfo->imb_org_bp) = inm_bio_error(&(mbufinfo->imb_pt_buf));   \
+	bio_endio(mbufinfo->imb_org_bp);                                                \
+}
+#else
 #define INM_PT_IODONE(mbufinfo)                                                 	\
 {                                                                               	\
 	mbufinfo->imb_org_bp->bi_flags = mbufinfo->imb_pt_buf.bi_flags;         	\
@@ -823,6 +844,7 @@ int _inm_xm_mapin(struct _target_context *, void *, char **);
 	inm_bio_error(mbufinfo->imb_org_bp) = inm_bio_error(&(mbufinfo->imb_pt_buf));   \
 	mbufinfo->imb_org_bp->bi_end_io(mbufinfo->imb_org_bp);                          \
 }
+#endif
 
 #define INM_BUF_FAILED(bp, error) 		inm_bio_error(bp)
 
@@ -962,7 +984,7 @@ inm_s32_t inm_blkdev_get(inm_bio_dev_t *bdev);
 #endif
 #endif
 
-#if defined(RHEL9_2) || defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
+#if defined(RHEL9_2) || defined(RHEL9_3) || defined(RHEL9_4) || defined(RHEL9_5) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER) || LINUX_VERSION_CODE >= KERNEL_VERSION(5,19,0)
 typedef struct {
     /* empty dummy */
 } mm_segment_t;
@@ -977,7 +999,7 @@ typedef struct {
 })
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0) || defined(RHEL9_6) || defined(RHEL9_7)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,8,0) || defined(RHEL9_6) || defined(RHEL9_7) || defined(RHEL9_8_OR_LATER)
 #define inm_freeze_bdev(__bdev, __sb)   bdev_freeze(__bdev)
 #define inm_thaw_bdev(__bdev, __sb)     bdev_thaw(__bdev)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,11,0)


### PR DESCRIPTION
Ports the latest `release` branch changes from InMage-ASRDFD on top of the 9.67 sync.

## Changes
- **10 source files updated** (`+205 / -54`):
  - `distro.h`, `filter_host.c/.h`, `osdep.c/.h`, `file-io.c`, `inm_mem.h`, `inm_utypes.h`, `flt_bio.h`, `Makefile`
- Key fixes/features ported:
  - `names_cachep` build failure fix for kernels **>= 6.12**
  - **SLES 16**, **Debian 13**, **Ubuntu 26.04** driver support
  - **RHEL 9.8+** kernel handling (`RHEL9_8_OR_LATER`) and Debian `DISTRO_VER` in Makefile
- Set `VERSION_BUILDNUM` to **7**

## Notes
- Only `src/` files were synced; build scripts, pipelines, and configs were intentionally not copied (ASRDFD keeps its own minimal build setup).
- No new or deleted source files relative to the previous sync.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>